### PR TITLE
Automate Unhandled Exception Wiring [iOS]

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -74,12 +74,12 @@ Task ("nuget")
 	.Does (() => 
 {
 	// NuGet on mac trims out the first ./ so adding it twice works around
-	var basePath = IsRunningOnUnix () ? "././" : "./";
+	var basePath = IsRunningOnUnix () ? (System.IO.Directory.GetCurrentDirectory().ToString() + @"/.") : "./";
 
 	NuGetPack ("./HockeySDK.nuspec", new NuGetPackSettings {
 		Version = NUGET_VERSION,
 		BasePath = basePath,
-		Verbosity = NuGetVerbosity.Detailed,
+		Verbosity = NuGetVerbosity.Detailed
 	});
 
 	if (!DirectoryExists ("./output"))

--- a/samples/HockeyAppSampleAndroid/MainActivity.cs
+++ b/samples/HockeyAppSampleAndroid/MainActivity.cs
@@ -14,39 +14,18 @@ namespace HockeyAppSampleAndroid
 {
 	[Activity (Label = "HockeyApp Sample", MainLauncher = true, Theme="@style/Theme.AppCompat.Light")]
 	public class MainActivity : Activity
-	{      
-        public const string HOCKEYAPP_APPID = "YOUR-APP-ID";
+	{
+		public const string HOCKEYAPP_APPID = "YOUR-APP-ID";
 
 		protected override void OnCreate (Bundle bundle)
 		{
 			base.OnCreate (bundle);
 
-            // Register the crash manager before Initializing the trace writer
-            HockeyApp.CrashManager.Register (this, HOCKEYAPP_APPID); 
+			// Register the crash manager before Initializing the trace writer
+			HockeyApp.CrashManager.Register (this, HOCKEYAPP_APPID); 
 
-            //Register to with the Update Manager
-            HockeyApp.UpdateManager.Register (this, HOCKEYAPP_APPID);
-
-            // Initialize the Trace Writer
-            HockeyApp.TraceWriter.Initialize ();
-
-            // Wire up Unhandled Expcetion handler from Android
-            AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) => 
-            {
-                // Use the trace writer to log exceptions so HockeyApp finds them
-                HockeyApp.TraceWriter.WriteTrace(args.Exception);
-                args.Handled = true;
-            };
-
-            // Wire up the .NET Unhandled Exception handler
-            AppDomain.CurrentDomain.UnhandledException +=
-                (sender, args) => HockeyApp.TraceWriter.WriteTrace(args.ExceptionObject);
-
-            // Wire up the unobserved task exception handler
-            TaskScheduler.UnobservedTaskException += 
-                (sender, args) => HockeyApp.TraceWriter.WriteTrace(args.Exception);
-
-
+			//Register to with the Update Manager
+			HockeyApp.UpdateManager.Register (this, HOCKEYAPP_APPID);
 
 			// Set our view from the "main" layout resource
 			SetContentView (Resource.Layout.Main);

--- a/samples/HockeyAppSampleiOS/AppDelegate.cs
+++ b/samples/HockeyAppSampleiOS/AppDelegate.cs
@@ -22,30 +22,19 @@ namespace HockeyAppSampleiOS
 
         public override bool FinishedLaunching (UIApplication app, NSDictionary options)
         {
-            Setup.EnableCustomCrashReporting (() => {
+            //Get the shared instance
+            var manager = BITHockeyManager.SharedHockeyManager;
 
-                //Get the shared instance
-                var manager = BITHockeyManager.SharedHockeyManager;
+            //Configure it to use our APP_ID
+            manager.Configure (HOCKEYAPP_APPID);
 
-                //Configure it to use our APP_ID
-                manager.Configure (HOCKEYAPP_APPID);
+            //Start the manager
+            manager.StartManager ();
 
-                //Start the manager
-                manager.StartManager ();
-
-                #if !CRASHONLY
-                //Authenticate (there are other authentication options)
-                manager.Authenticator.AuthenticateInstallation ();
-                #endif
-
-                //Rethrow any unhandled .NET exceptions as native iOS 
-                // exceptions so the stack traces appear nicely in HockeyApp
-                AppDomain.CurrentDomain.UnhandledException += (sender, e) => 
-                    Setup.ThrowExceptionAsNative (e.ExceptionObject);
-
-                TaskScheduler.UnobservedTaskException += (sender, e) => 
-                    Setup.ThrowExceptionAsNative (e.Exception);
-            });
+            #if !CRASHONLY
+            //Authenticate (there are other authentication options)
+            manager.Authenticator.AuthenticateInstallation ();
+            #endif
 
             // create a new window instance based on the screen size
             window = new UIWindow (UIScreen.MainScreen.Bounds);

--- a/source/android/Additions/CrashManager.cs
+++ b/source/android/Additions/CrashManager.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Android.Runtime;
+using System.Threading.Tasks;
+
+namespace HockeyApp
+{
+	public partial class CrashManager
+	{
+		public static void Register(global::Android.Content.Context context)
+		{
+			DoRegister(context);
+			ConnectUnhandledExceptionEvents();
+		}
+
+		public static void Register(global::Android.Content.Context context, string appIdentifier)
+		{
+			DoRegister(context, appIdentifier);
+			ConnectUnhandledExceptionEvents();
+		}
+
+		public static void Register(global::Android.Content.Context context, string appIdentifier, global::HockeyApp.CrashManagerListener listener)
+		{
+			DoRegister(context, appIdentifier, listener);
+			ConnectUnhandledExceptionEvents();
+		}
+			
+		public static void Register(global::Android.Content.Context context, string urlString, string appIdentifier, global::HockeyApp.CrashManagerListener listener)
+		{
+			DoRegister(context, urlString, appIdentifier, listener);
+			ConnectUnhandledExceptionEvents();
+		}
+
+		private static void ConnectUnhandledExceptionEvents()
+		{
+			TraceWriter.Initialize();
+
+			AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => {
+				TraceWriter.WriteTrace(e.Exception);
+				e.Handled = true;
+			};
+
+			AppDomain.CurrentDomain.UnhandledException += (sender, e) => TraceWriter.WriteTrace(e.ExceptionObject);;
+
+			TaskScheduler.UnobservedTaskException += (sender, e) => TraceWriter.WriteTrace(e.Exception);
+		}
+	}
+}
+

--- a/source/android/Additions/CrashManager.cs
+++ b/source/android/Additions/CrashManager.cs
@@ -52,13 +52,8 @@ namespace HockeyApp
 
 				TraceWriter.Initialize();
 
-				AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => {
-					TraceWriter.WriteTrace(e.Exception);
-					e.Handled = true;
-				};
-
+				AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => TraceWriter.WriteTrace(e.Exception);
 				AppDomain.CurrentDomain.UnhandledException += (sender, e) => TraceWriter.WriteTrace(e.ExceptionObject);
-
 				TaskScheduler.UnobservedTaskException += (sender, e) => TraceWriter.WriteTrace(e.Exception);
 
 				connectedToUnhandledExceptionEvents = true;

--- a/source/android/Additions/TraceWriter.cs
+++ b/source/android/Additions/TraceWriter.cs
@@ -10,7 +10,7 @@ using Process = System.Diagnostics.Process;
 
 namespace HockeyApp
 {
-    public static class TraceWriter
+    internal static class TraceWriter
     {
         private static CrashManagerListener _Listener;
 

--- a/source/android/HockeySDK.Android.csproj
+++ b/source/android/HockeySDK.Android.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Additions\TraceWriter.cs" />
+    <Compile Include="Additions\CrashManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />

--- a/source/android/Transforms/Metadata.xml
+++ b/source/android/Transforms/Metadata.xml
@@ -26,6 +26,7 @@
   <attr path="/api/package[@name='net.hockeyapp.android.views']" name="managedName">HockeyApp.Views</attr>
 
   <!-- Remapping CrashManager Register Methods in order to Add C# Extension Methods -->
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='CrashManager' and count(parameter)=0]" name="visibility">private</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=1 and parameter[1][@type='android.content.Context']]" name="visibility">internal</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=1 and parameter[1][@type='android.content.Context']]" name="managedName">DoRegister</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=2 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String']]" name="visibility">internal</attr>

--- a/source/android/Transforms/Metadata.xml
+++ b/source/android/Transforms/Metadata.xml
@@ -25,6 +25,16 @@
   <attr path="/api/package[@name='net.hockeyapp.android.utils']" name="managedName">HockeyApp.Utils</attr>
   <attr path="/api/package[@name='net.hockeyapp.android.views']" name="managedName">HockeyApp.Views</attr>
 
+  <!-- Remapping CrashManager Register Methods in order to Add C# Extension Methods -->
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=1 and parameter[1][@type='android.content.Context']]" name="visibility">internal</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=1 and parameter[1][@type='android.content.Context']]" name="managedName">DoRegister</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=2 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String']]" name="visibility">internal</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=2 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String']]" name="managedName">DoRegister</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=3 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='net.hockeyapp.android.CrashManagerListener']]" name="visibility">internal</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=3 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='net.hockeyapp.android.CrashManagerListener']]" name="managedName">DoRegister</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=4 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='java.lang.String'] and parameter[4][@type='net.hockeyapp.android.CrashManagerListener']]" name="visibility">internal</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=4 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='java.lang.String'] and parameter[4][@type='net.hockeyapp.android.CrashManagerListener']]" name="managedName">DoRegister</attr>
+
 
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='UpdateActivity']/method[@name='getLayoutView']" name="managedReturn">Android.Views.View</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='FeedbackActivity']/method[@name='getLayoutView']" name="managedReturn">Android.Views.View</attr>

--- a/source/ios/ApiDefinition.cs
+++ b/source/ios/ApiDefinition.cs
@@ -50,6 +50,7 @@ namespace HockeyApp
     }
 
     [BaseType (typeof(NSObject))]
+    [DisableDefaultCtor]
     public partial interface BITHockeyManager
     {
         [Static]
@@ -71,8 +72,9 @@ namespace HockeyApp
         [Export("configureWithBetaIdentifier:liveIdentifier:delegate:")]
         void ConfigureWithIdentifier(string betaIdentifier, string liveIdentifier, NSObject managerDelegate);
 
+        [Internal]
         [Export("startManager")]
-        void StartManager();
+        void DoStartManager();
 
         [Export ("serverURL", ArgumentSemantic.Retain)]
         string ServerURL { get; set; }


### PR DESCRIPTION
- Hides internal startManager as `internal void DoStartManager`
- Disable default constructor for BitHockeyManager
- Refactors Setup as partial class of BITHockeyManager
- Inserts C# UnhandledExceptionEvent subscriptions to StartManager
- Adds variables for thread protection against multiple StartManager
calls

@gordallott @njpatel 

depends on #2 