### PR TITLE
Update TraceWriter.cs

### DIFF
--- a/source/android/Additions/TraceWriter.cs
+++ b/source/android/Additions/TraceWriter.cs
@@ -10,7 +10,7 @@ using Process = System.Diagnostics.Process;
 
 namespace HockeyApp
 {
-    internal static class TraceWriter
+    public static class TraceWriter
     {
         private static CrashManagerListener _Listener;
 
@@ -80,7 +80,7 @@ namespace HockeyApp
          to
          \tat android.support.v4.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1343)
         */
-        static Regex _StackTraceLine = new Regex(@"\s*at\s*(\S+)\s*\(([^\)]*)\)");
+        static Regex _StackTraceLine = new Regex(@"\s*at\s*(\S+)\s*\([^\)]*\)\s\[0x[\d\w]+\]\sin\s\S+[\\/](\S+)");
 
         /// <summary>
         /// Writes the given object (usually an exception) to disc so that it can be picked up by the CrashManager and send to Hockeyapp.
@@ -173,11 +173,9 @@ namespace HockeyApp
                                         }
                                         //this forces the arguments part to look more like the file line number part that
                                         //android stack traces normally have
-                                        var arguments = m.Groups[2].Value.Trim();
-                                        arguments = arguments.Replace(' ', '_');
-                                        arguments = arguments.Replace(',', '_');
+                                        var fileAndLine = m.Groups[2].Value.Trim();
 
-                                        sw.WriteLine("\tat {0}({1}.args:1337)", method, arguments);
+                                        sw.WriteLine("\tat {0}({1})", method, fileAndLine);
                                     }
                                 }
                             }


### PR DESCRIPTION
This class shoud be public, or provide another method to log non-fatal exceptions.

This change the call stack from:

```
System.Net.WebException: Error: TrustFailure (The authentication or decryption has failed.)
	at System.Net.HttpWebRequest.EndGetRequestStream(IAsyncResult_asyncResult.args:1337)
	at System.Threading.Tasks.TaskFactory`1[TResult].FromAsyncCoreLogic(IAsyncResult_iar__System.Func`2_endFunction__System.Action`1_endAction__System.Threading.Tasks.Task`1_promise__Boolean_requiresSynchronization.args:1337)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult(.args:1337)
	at System.Net.Http.HttpClientHandler+<SendAsync>c__async0.MoveNext(.args:1337)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult(.args:1337)
	at System.Net.Http.HttpClient+<SendAsyncWorker>c__async0.MoveNext(.args:1337)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(.args:1337)
	at dies.mobile.droid.Dies.Mobile.Core.Loaders.Loader+<LoadHtmlNode>c__async2.MoveNext(.args:1337)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(.args:1337)
	at dies.mobile.droid.Dies.Mobile.Core.Loaders.ProjudiLoader+<LoadProcessoAsync>c__async0.MoveNext(.args:1337)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(System.Threading.Tasks.Task_task.args:1337)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(.args:1337)
	at dies.mobile.droid.Dies.Mobile.Core.AddTrialByNumberViewModel+<AddTrialByNumber>c__async0.MoveNext(.args:1337)

```
To:

```
System.Net.WebException: Error: TrustFailure (The authentication or decryption has failed.)
	at System.Net.HttpWebRequest.EndGetResponse(HttpWebRequest.cs:1005)
	at System.Threading.Tasks.TaskFactory`1[TResult].FromAsyncCoreLogic(FutureFactory.cs:550)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(exceptionservicescommon.cs:143)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(TaskAwaiter.cs:187)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(TaskAwaiter.cs:156)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(TaskAwaiter.cs:128)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(TaskAwaiter.cs:357)
	at dies.mobile.droid.MakerPlanet.Mobile.Dies.Loaders.HtmlDownloader+<GetStreamAsync>c__async3.MoveNext(HtmlDownloader.cs:82)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(exceptionservicescommon.cs:143)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(TaskAwaiter.cs:187)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(TaskAwaiter.cs:156)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(TaskAwaiter.cs:128)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(TaskAwaiter.cs:357)
	at dies.mobile.droid.MakerPlanet.Mobile.Dies.Loaders.HtmlDownloader+<GetHtmlNodeAsync>c__async1.MoveNext(HtmlDownloader.cs:30)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(exceptionservicescommon.cs:143)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(TaskAwaiter.cs:187)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(TaskAwaiter.cs:156)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(TaskAwaiter.cs:128)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(TaskAwaiter.cs:357)
	at dies.mobile.droid.MakerPlanet.Mobile.Dies.Loaders.HtmlDownloader+<GetHtmlNodeAsync>c__async0.MoveNext(HtmlDownloader.cs:24)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(exceptionservicescommon.cs:143)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(TaskAwaiter.cs:187)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(TaskAwaiter.cs:156)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(TaskAwaiter.cs:128)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(TaskAwaiter.cs:357)
	at dies.mobile.droid.Dies.Mobile.Core.Loaders.PjeLoader+<LoadProcessoAsync>c__async0.MoveNext(PjeLoader.cs:44)
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(exceptionservicescommon.cs:143)
	at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(TaskAwaiter.cs:187)
	at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(TaskAwaiter.cs:156)
	at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(TaskAwaiter.cs:128)
	at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult(TaskAwaiter.cs:357)
	at dies.mobile.droid.Dies.Mobile.Core.AddTrialByNumberViewModel+<AddTrialByNumber>c__async0.MoveNext(AddTrialByNumberViewModel.cs:91)

```
Which is correct.