### PR TITLE
Update iOS binary url to 4.1.0-beta.2

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,8 @@ var COMPONENT_VERSION = "4.1.0";
 var NUGET_VERSION = "4.1.0-beta1";
 
 var ANDROID_URL = "https://s3.amazonaws.com/hockey-app-download/sdk/xamarin/android/HockeySDK-Android-4.1.0-beta.2.zip";
-var IOS_URL = "https://s3.amazonaws.com/hockey-app-download/sdk/xamarin/ios/HockeySDK-iOS-4.1.0-beta.1.zip";
+var IOS_URL = "https://s3.amazonaws.com/hockey-app-download/sdk/xamarin/ios/HockeySDK-iOS-4.1.0-beta.2.zip";
+
 var SAMPLES = new [] {
 	"./samples/HockeyAppSampleAndroid.sln",
 	// "./samples/HockeyAppSampleiOS.sln",


### PR DESCRIPTION
updates native iOS binary to [4.1.0-beta.2](https://github.com/bitstadium/HockeySDK-iOS/releases/tag/4.1.0-beta.2)
