### PR TITLE
Fix property name in example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ using HockeyApp.iOS;
 
 var manager = BITHockeyManager.SharedHockeyManager;
 manager.Configure("Your_App_Id");
-manager.SetDisableUpdateManager = true;
+manager.DisableUpdateManager = true;
 manager.StartManager();
 ```
 


### PR DESCRIPTION
A simple typo fix in README for example code disabling update manager.