### PR TITLE
Fixes #57 -- Renamed BITCrashMetaData.UserDescription to BITCrashMetaData.UserProvidedDescription

### DIFF
--- a/source/HockeySDK.iOSBindings/ApiDefinition.cs
+++ b/source/HockeySDK.iOSBindings/ApiDefinition.cs
@@ -451,8 +451,8 @@ namespace HockeyApp.iOS
     public partial interface BITCrashMetaData {
 
         // @property (copy, nonatomic) NSString * userDescription;
-        [Export ("userDescription")]
-        string UserDescription { get; set; }
+        [Export ("userProvidedDescription")]
+        string UserProvidedDescription { get; set; }
 
         // @property (copy, nonatomic) NSString * userName;
         [Export ("userName")]


### PR DESCRIPTION
Renamed `BITCrashMetaData.UserDescription` to `BITCrashMetaData.UserProvidedDescription` to match the iOS SDK so that it doesn't provide a false positive in using an Apple private API when submitting to the App Store.