### PR TITLE
Revert change that tried to fix behavior to catch .net exception stac…

### DIFF
--- a/source/HockeySDK.iOSBindings/ApiDefinition.cs
+++ b/source/HockeySDK.iOSBindings/ApiDefinition.cs
@@ -79,8 +79,8 @@ namespace HockeyApp.iOS
         void ConfigureWithIdentifier(string betaIdentifier, string liveIdentifier, [NullAllowed] NSObject managerDelegate);
 
         [Internal]
-		[Export("startManagerInXamarinEnvironment")]
-        void DoStartManager();
+		[Export("startManager")]
+		void DoStartManager();
 
         [Export ("serverURL", ArgumentSemantic.Retain)]
         string ServerURL { get; set; }


### PR DESCRIPTION
…ktraces

This fixes a regression that was introduced in the last release that caused incomplete crash reports for .Net exceptions.
This PR fixes it but will cause the debugger to not be able to catch NSExceptions. Those will be caught by hockeyapp, though. To fix this, the native iOS SDK as well as the Xamarin SDK will need to undergo a significant refactoring which we can't do now.

See #71.