### PR TITLE
Bind Initialize properly

### DIFF
--- a/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
+++ b/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
@@ -41,6 +41,18 @@ namespace HockeyApp.Android
 			ConnectUnhandledExceptionEvents(listener);
 		}
 
+        public static void Initialize(global::Android.Content.Context context, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
+        {
+            DoInitialize(context, appIdentifier, listener);
+            ConnectUnhandledExceptionEvents(listener);
+        }
+
+        public static void Initialize(global::Android.Content.Context context, string urlString, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
+        {
+            DoInitialize(context, urlString, appIdentifier, listener);
+            ConnectUnhandledExceptionEvents(listener);
+        }
+
 		private static void ConnectUnhandledExceptionEvents(global::HockeyApp.Android.CrashManagerListener listener = null)
 		{
 			if (connectedToUnhandledExceptionEvents)

--- a/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
+++ b/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
@@ -34,24 +34,24 @@ namespace HockeyApp.Android
 			DoRegister(context, appIdentifier, listener);
 			ConnectUnhandledExceptionEvents(listener);
 		}
-			
+
 		public static void Register(global::Android.Content.Context context, string urlString, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
 		{
 			DoRegister(context, urlString, appIdentifier, listener);
 			ConnectUnhandledExceptionEvents(listener);
 		}
 
-        public static void Initialize(global::Android.Content.Context context, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
-        {
-            DoInitialize(context, appIdentifier, listener);
-            ConnectUnhandledExceptionEvents(listener);
-        }
+		public static void Initialize(global::Android.Content.Context context, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
+		{
+			DoInitialize(context, appIdentifier, listener);
+			ConnectUnhandledExceptionEvents(listener);
+		}
 
-        public static void Initialize(global::Android.Content.Context context, string urlString, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
-        {
-            DoInitialize(context, urlString, appIdentifier, listener);
-            ConnectUnhandledExceptionEvents(listener);
-        }
+		public static void Initialize(global::Android.Content.Context context, string urlString, string appIdentifier, global::HockeyApp.Android.CrashManagerListener listener)
+		{
+			DoInitialize(context, urlString, appIdentifier, listener);
+			ConnectUnhandledExceptionEvents(listener);
+		}
 
 		private static void ConnectUnhandledExceptionEvents(global::HockeyApp.Android.CrashManagerListener listener = null)
 		{

--- a/source/HockeySDK.AndroidBindings/Transforms/Metadata.xml
+++ b/source/HockeySDK.AndroidBindings/Transforms/Metadata.xml
@@ -25,7 +25,7 @@
   <attr path="/api/package[@name='net.hockeyapp.android.utils']" name="managedName">HockeyApp.Android.Utils</attr>
   <attr path="/api/package[@name='net.hockeyapp.android.views']" name="managedName">HockeyApp.Android.Views</attr>
 
-  <!-- Remapping CrashManager Register Methods in order to Add C# Extension Methods -->
+  <!-- Remapping CrashManager Register and Initialize Methods in order to Add C# Extension Methods -->
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='CrashManager' and count(parameter)=0]" name="visibility">private</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=1 and parameter[1][@type='android.content.Context']]" name="visibility">internal</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=1 and parameter[1][@type='android.content.Context']]" name="managedName">DoRegister</attr>
@@ -36,7 +36,11 @@
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=4 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='java.lang.String'] and parameter[4][@type='net.hockeyapp.android.CrashManagerListener']]" name="visibility">internal</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='register' and count(parameter)=4 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='java.lang.String'] and parameter[4][@type='net.hockeyapp.android.CrashManagerListener']]" name="managedName">DoRegister</attr>
 
-
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='initialize' and count(parameter)=3 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='net.hockeyapp.android.CrashManagerListener']]" name="visibility">internal</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='initialize' and count(parameter)=3 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='net.hockeyapp.android.CrashManagerListener']]" name="managedName">DoInitialize</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='initialize' and count(parameter)=4 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='java.lang.String'] and parameter[4][@type='net.hockeyapp.android.CrashManagerListener']]" name="visibility">internal</attr>
+  <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='CrashManager']/method[@name='initialize' and count(parameter)=4 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='java.lang.String'] and parameter[4][@type='net.hockeyapp.android.CrashManagerListener']]" name="managedName">DoInitialize</attr>
+	
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='UpdateActivity']/method[@name='getLayoutView']" name="managedReturn">Android.Views.View</attr>
   <attr path="/api/package[@name='net.hockeyapp.android']/class[@name='FeedbackActivity']/method[@name='getLayoutView']" name="managedReturn">Android.Views.View</attr>
 


### PR DESCRIPTION
Solve an issue with insufficient crash reports when using separate calls to `CrashManager.Initialize()` and `CrashManager.Execute()`.
The reason was that `Initialize()` needs to be proxied to initialize `TraceWriter.cs`.