### PR TITLE
Check .Observed before logging UnobservedTaskException

### DIFF
--- a/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
+++ b/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
@@ -73,14 +73,14 @@ namespace HockeyApp.Android
 
 				AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => TraceWriter.WriteTrace(e.Exception);
 				AppDomain.CurrentDomain.UnhandledException += (sender, e) => TraceWriter.WriteTrace(e.ExceptionObject);
-                TaskScheduler.UnobservedTaskException += (sender, e) =>
-                {
-                    if (!e.Observed)
-                    {
-                        TraceWriter.WriteTrace(e.Exception, terminateOnUnobservedTaskException);
-                    }
-                };
-                connectedToUnhandledExceptionEvents = true;
+				TaskScheduler.UnobservedTaskException += (sender, e) =>
+				{
+						if (!e.Observed)
+						{
+								TraceWriter.WriteTrace(e.Exception, terminateOnUnobservedTaskException);
+						}
+				};
+				connectedToUnhandledExceptionEvents = true;
 			}
 		}
 	}

--- a/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
+++ b/source/HockeySDK.AndroidBindings/Additions/CrashManager.cs
@@ -73,9 +73,14 @@ namespace HockeyApp.Android
 
 				AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => TraceWriter.WriteTrace(e.Exception);
 				AppDomain.CurrentDomain.UnhandledException += (sender, e) => TraceWriter.WriteTrace(e.ExceptionObject);
-				TaskScheduler.UnobservedTaskException += (sender, e) => TraceWriter.WriteTrace(e.Exception, terminateOnUnobservedTaskException);
-
-				connectedToUnhandledExceptionEvents = true;
+                TaskScheduler.UnobservedTaskException += (sender, e) =>
+                {
+                    if (!e.Observed)
+                    {
+                        TraceWriter.WriteTrace(e.Exception, terminateOnUnobservedTaskException);
+                    }
+                };
+                connectedToUnhandledExceptionEvents = true;
 			}
 		}
 	}


### PR DESCRIPTION
The goal of this PR is to fix an issue [TaskException is sent even if it is marked as Observed](https://github.com/bitstadium/HockeySDK-Xamarin/issues/130)